### PR TITLE
Increase search debounce timeout

### DIFF
--- a/site_script.js
+++ b/site_script.js
@@ -184,7 +184,7 @@
       window.history.replaceState(null, '', '/');
     }
     search(value);
-  }, 50), false);
+  }, 200), false);
   $searchClose.addEventListener('click', function(e) {
     e.stopPropagation();
 


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue:**


### Description
Increase debounce timeout from `50` to `200` in order to make search a bit less heavy on the end users computer. I tested values ranging from `100` to `1000`, and `200` seemed to be the highest value at which the responsiveness still "felt good".